### PR TITLE
Update event name

### DIFF
--- a/events.json.config
+++ b/events.json.config
@@ -8,7 +8,7 @@ permalink: /events.json
   {
     "@context": "https://schema.org",
     "@type": "Event",
-    "name": {{ event.title | jsonify }},
+    "name": {{ event.name | default: event.title | jsonify }},
     "url": "{{ event.url | absolute_url }}",
     "image": {{ event.image | jsonify }},
     "eventStatus": "{{ event.eventStatus | default: 'EventScheduled' }}",


### PR DESCRIPTION
Use `event.name` instead of `event.title` by default.