### PR TITLE
Fix creating JSON version of events

### DIFF
--- a/events.json.config
+++ b/events.json.config
@@ -18,21 +18,32 @@ permalink: /events.json
     "endDate": "{{ event.endDate | date_to_xmlschema }}",
     "organizer": {
     	"@type": "{{ event.organizer['@type'] | default: 'Organization' }}",
-    	"name": {{ event.organizer.name | jsonify }},
-    	"url": {{ event.organizer.url | jsonify }}
+    	"name": {{ event.organizer.name | jsonify }}{% if event.organizer.url %},
+    	"url": {{ event.organizer.url | jsonify }}{% endif %}{% if event.organizer.email %},
+    	"email": {{ event.organizer.email | jsonify }}{% endif %}{% if event.organizer.telephone %},
+    	"telephone": {{ event.organizer.telephone | jsonify }}{% endif %}{% if event.organizer.sameAs %},
+    	"sameAs": {{ event.organizer.sameAs | jsonify }}{% endif %}
     },
     "location": {
-      "@type": "Place",
-      "name": "{{ event.location.name }}",
-      "address": {
+      "@type": "{{ event.location['@type'] | default: 'Place' }}",
+      "name": "{{ event.location.address.name }}",
+      "address": {% if event.location.address %}{
+        "@type": "{{ event.location.address['@type'] | default: 'PostalAddress' }}",
+        "streetAddress": {{ event.location.address.streetAddress | jsonify }},
+        "addressLocality": "{{ event.location.address.addressLocality }}",
+        "addressRegion": "{{ event.location.address.addressRegion | default: 'CA' }}",
+        "postalCode": {{ event.location.address.postalCode | jsonify }},
+        "addressCountry": "{{ event.location.addressCountry | default: 'US' }}"
+      }{% else %}{
         "@type": "PostalAddress",
         "streetAddress": {{ event.location.streetAddress | jsonify }},
         "addressLocality": "{{ event.location.addressLocality }}",
         "addressRegion": "{{ event.location.addressRegion | default: 'CA' }}",
-        "postalCode": {{ event.location.postalCode | jsonify }}
-      },
+        "postalCode": {{ event.location.postalCode | jsonify }},
+        "addressCountry": "{{ event.location.addressCountry | default: 'US' }}"
+      }{% endif %},
       "geo": {
-        "@type": "GeoCoordinates",
+        "@type": "{{ event.location.geo['@type'] | default: 'GeoCoordinates' }}",
         "longitude": {{ event.location.geo.longitude | jsonify }},
         "latitude": {{ event.location.geo.latitude | jsonify }}
       }


### PR DESCRIPTION
- Handle `event.location.address` if set, and `event.location` otherwise for addresses
- Allow for more custom `"@type"`s
- Add `telephone`, `email`, & `sameAs` to event organizers