### PR TITLE
Add 2025 event pages and update event template

### DIFF
--- a/_events/2025/2025-09-25-kern-river-rock-n-blues-fest.md
+++ b/_events/2025/2025-09-25-kern-river-rock-n-blues-fest.md
@@ -1,0 +1,40 @@
+---
+"@context": https://schema.org
+"@type": MusicEvent
+layout: redirect
+redirect: https://www.facebook.com/events/1275535624050847/
+date: 2025-09-25
+name: Kern River Rock n Blues Fest
+title: Kern River Rock n Blues Fest
+description: Tito's Handmade Vodka KERN RIVER ROCK n BLUES FEST presented by
+  Mountain Dog Millworks is Kern County's Rock n Blues Reu
+tags:
+  - kernville
+  - dance
+  - music
+  - concert
+  - social
+startDate: 2025-09-25T20:00
+endDate: 2025-09-28T14:00
+eventAttendanceMode: OfflineEventAttendanceMode
+image: https://i.imgur.com/dnGU3h2l.jpeg
+organizer:
+  "@type": LocalBusiness
+  name: Notorious Entertainment
+  email: orion.notoriousentertainment@gmail.com
+  url: http://notoriousent.net/
+location:
+  "@type": Campground
+  name: Frandy Park Campground
+  address:
+    "@type": PostalAddress
+    streetAddress: 11252 Kernville Rd.
+    addressLocality: Kernville
+    addressRegion: CA
+    postalCode: 93238
+    addressCountry: US
+  geo:
+    "@type": GeoCoordinates
+    latitude: 35.7541800458006
+    longitude: -118.42168650778954
+---

--- a/_events/2025/2025-10-18-rivernook-campground-beer-and-music-festival.md
+++ b/_events/2025/2025-10-18-rivernook-campground-beer-and-music-festival.md
@@ -1,0 +1,62 @@
+---
+"@context": https://schema.org
+"@type": Festival
+layout: redirect
+redirect: https://www.rivernookcampground.com/beerfest
+date: 2025-10-18
+name: Rivernook Campground Beer and Music Festival
+title: Rivernook Campground Beer and Music Festival
+description: The annual Rivernook Campground Beer & Music Festival is a
+  Non-Profit event benefiting our local Dog Rescue
+tags:
+  - kernville
+  - festival
+  - dance
+  - music
+  - concert
+  - social
+  - outdoors
+  - fundraiser
+startDate: 2025-10-18T12:00
+endDate: 2025-10-18T17:00
+eventAttendanceMode: OfflineEventAttendanceMode
+image: https://i.imgur.com/gMefkb0l.png
+organizer:
+  "@type": LocalBusiness
+  name: Rivernook Campground
+  email: info@rivernookcampground.com
+  url: https://rivernookcampground.com/
+location:
+  "@type": Campground
+  name: Rivernook Campground
+  address:
+    "@type": PostalAddress
+    streetAddress: 14001 Sierra Way
+    addressLocality: Kernville
+    addressRegion: CA
+    postalCode: 93238
+    addressCountry: US
+  geo:
+    "@type": GeoCoordinates
+    latitude: -118.423541
+    longitude: 35.763118
+offers:
+  - name: VIP
+    price: 105.00
+    currency: USD
+    url: https://www.rivernookcampground.com/event-details/2025-rivernook-campground-beer-music-festival
+    validFrom: 2025-08-03 00:00
+    validThrough: 2025-10-18 12:00
+  - name: General Admission
+    price: 75.00
+    currency: USD
+    url: https://www.rivernookcampground.com/event-details/2025-rivernook-campground-beer-music-festival
+    validFrom: 2025-08-03 00:00
+    validThrough: 2025-10-18 12:00
+  - name: Designated Driver
+    price: 25.00
+    currency: USD
+    url: https://www.rivernookcampground.com/event-details/2025-rivernook-campground-beer-music-festival
+    validFrom: 2025-08-03 00:00
+    validThrough: 2025-10-18 12:00
+---

--- a/_includes/event.html
+++ b/_includes/event.html
@@ -2,6 +2,11 @@
 	<div>
 		<link itemprop="eventStatus" content="https://schema.org/{{ include.eventStatus | default: 'EventScheduled' }}" />
 		<link itemprop="eventAttendanceMode" content="https://schema.org/{{ include.eventAttendanceMode | default: 'OfflineEventAttendanceMode' }}" />
+		{% if include.event.tags %}
+			{% for keyword in include.event.tags %}
+				<meta itemprop="keywords" content="{{ keyword }}" />
+			{% endfor %}
+		{% endif %}
 		{% if include.event.redirect %}
 			<a href="{{ include.event.redirect }}?utm_source=krv-events&amp;utm_medium=referrer" rel="noopener referrer external">
 		{% elsif include.event.url %}<a href="{{ include.event.url }}">{% endif %}
@@ -153,7 +158,7 @@
 			</div>
 		{% endif %}
 		{% if include.event.funding %}
-			<div itemprop="funding" itemtype="https://scheme.org/{{ include.event.funding['@type'] | default: 'Grant' }}" itemscope="" hidden="">
+			<div itemprop="funding" itemtype="https://schema.org/{{ include.event.funding['@type'] | default: 'Grant' }}" itemscope="" hidden="">
 				<meta itemprop="name" content="{{ include.event.funding.name }}" />
 				{% if include.event.funding.url %}
 					<link itemprop="url" href="{{ include.event.funding.url }}" />


### PR DESCRIPTION
Added new event markdown files for Kern River Rock n Blues Fest and Rivernook Campground Beer and Music Festival in 2025. Updated event.html to render event tags as meta keywords and fixed a typo in the funding itemtype URL from 'scheme.org' to 'schema.org'.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
