### PR TITLE
Add CWPP event and fix event include template

### DIFF
--- a/_events/2026/2026-06-16-cwpp-community-meeting.md
+++ b/_events/2026/2026-06-16-cwpp-community-meeting.md
@@ -1,0 +1,44 @@
+---
+"@context": https://schema.org
+"@type": Event
+layout: redirect
+redirect: https://kernfiresafe.org/event-registry/kern-county-cwpp-community-meeting-kern-river-valley
+date: 2026-06-16
+name: CWPP Community Meeting
+title: CWPP Community Meeting
+description: Help shape the Kern County Wildfire Protection Plan. Share local wildfire risks and learn how to prepare your community.
+tags:
+  - lake-isabella
+  - educational
+  - informational
+  - emergency
+  - nonprofit
+  - indoors
+startDate: 2026-06-16T18:00
+endDate: 2026-06-16T20:00
+eventAttendanceMode: OfflineEventAttendanceMode
+image: https://i.imgur.com/OFjZ6kSm.webp
+thumbnail:
+  url: https://i.imgur.com/OFjZ6kSm.webp
+  width: 574
+  height: 428
+organizer:
+  "@type": Organization
+  name: Kern Fire Safe Council
+  email: info@kernfiresafe.org
+  url: https://kernfiresafe.org/
+location:
+  "@type": Place
+  name: Kern River Valley Senior Center
+  address:
+    "@type": PostalAddress
+    streetAddress: 6405 Lake Isabella Blvd
+    addressLocality: Lake Isabella
+    addressRegion: CA
+    postalCode: 93240
+    addressCountry: US
+  geo:
+    "@type": GeoCoordinates
+    latitude: 35.6239716
+    longitude: -118.4758657
+---

--- a/_includes/event.html
+++ b/_includes/event.html
@@ -138,7 +138,7 @@
 		{% endif %}
 		{% if include.event.redirect %}
 			{% include common/icon.html icon='link' %}
-			<a href="{{ include.event.redirect }}?utm_souce=krv-events&amp;utm_medium=referrer" rel="noopener referrer external" class="underline" itemprop="url">Click here to learn more</a>
+			<a href="{{ include.event.redirect }}?utm_source=krv-events&amp;utm_medium=referrer" rel="noopener referrer external" class="underline" itemprop="url">Click here to learn more</a>
 		{% elsif include.event.url %}
 			{% include common/icon.html icon='link' %}
 			<a href="{{ include.event.url }}" class="underline" itemprop="url">Click here to learn more</a>

--- a/_includes/event.html
+++ b/_includes/event.html
@@ -60,15 +60,15 @@
 	</div>
 	<div class="event-location" itemprop="location"
 		itemtype="http://schema.org/{{ include.event.location['@type'] | default: 'Place' }}" itemscope="">
-		{% if event.location.name %}
+		{% if include.event.location.name %}
 			{% if event.location['@type'] == 'VirtualLocation' %}
-				<a href="{{ event.location.url }}" itemprop="url" target="_blank" rel="noopener noreferrer external">
+				<a href="{{ include.event.location.url }}" itemprop="url" target="_blank" rel="noopener noreferrer external">
 					{% include common/icon.html icon="link-external" fill="currentColor" height="16" width="16" %}
 					<b class="event-location-name" itemprop="name">{{ event.location.name }}</b>
 				</a>
 			{% else %}
 				{% include common/icon.html icon="location" fill="currentColor" height="16" width="16" %}
-				<b class="event-location-name" itemprop="name">{{ event.location.name }}</b>
+				<b class="event-location-name" itemprop="name">{{ include.event.location.name }}</b>
 			{% endif %}
 		{% endif %}
 		{% if include.event.location.addressRegion %}
@@ -80,7 +80,7 @@
 	<details class="event-details"{% if include.hideDetails %} hidden=""{% endif %}>
 		<summary role="button" class="btn btn-primary">{% include common/icon.html icon="view-more" height=16 width=16 fill="currentColor" %}Event Details</summary>
 		<br />
-		<time class="event-end" itemprop="endDate" datetime="{{ include.event.startDate | date_to_xmlschema }}">
+		<time class="event-end" itemprop="endDate" datetime="{{ include.event.endDate | date_to_xmlschema }}">
 			{% include common/icon.html icon='events' %}
 			<span>Ends:</span>
 			{{ include.event.endDate | date: '%a %b %-d, %Y %l:%M %p' }}
@@ -105,7 +105,7 @@
 		<div class="event-description" itemprop="description">
 			{% include common/icon.html icon='note' %}{{ include.event.description }}
 		</div>
-		{% if include.event.offers %}<div>{% for offer in include.event.offers %}
+		{% if include.event.offers and include.event.offers.size > 0 %}<div>{% for offer in include.event.offers %}
 			<hr />
 			{% if offer.url %}
 				<a href="{{ offer.url }}" role="button" rel="noopener external" class="center btn btn-primary block event-offer-btn" itemprop="offers" itemtype="http://schema.org/Offer" itemscope=""{% if offer.availability and offer.availability != 'InStock' %} title="Unavailable" disabled=""{% endif %}>
@@ -127,7 +127,7 @@
 				</div>
 			{% endif %}
 		{% endfor %}</div>{% else %}
-			<div class="center btn btn-primary block" itemprop="offers" itemtype="http://schema.org/Offer" itemscope="">
+			<div class="center btn btn-primary block" itemprop="offers" itemtype="http://schema.org/Offer" itemscope="" hidden="">
 				<b class="event-price">
 					<span itemprop="name">Admission</span>:
 					<span>Free</span>


### PR DESCRIPTION
Add new CWPP Community Meeting event (2026-06-16) with schema metadata and redirect to the external event registry. Update _includes/event.html to consistently use include.event for passed data (including VirtualLocation URL and location name), fix the endDate datetime to use endDate, only render offers when the offers array has items, and hide the default free-admission offer when no offers are provided.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
